### PR TITLE
fix: parse style strings for React

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -13,7 +13,7 @@ declare namespace React {
   }
 
   // Teact feature
-  interface CSSProperties extends String {}
+  type CSSProperties = string | Record<string, string>;
 
   interface Attributes {
     // Optimization for DOM nodes reordering. Requires `teactFastList` for parent

--- a/src/lib/react-utils/index.ts
+++ b/src/lib/react-utils/index.ts
@@ -1,8 +1,10 @@
 // Main React compatibility layer for Teact migration
 import React from 'react';
+import { createElement as compatCreateElement } from './memo';
 
-// Re-export all React functionality
-export default React;
+// Re-export all React functionality with Teact-style createElement
+const ReactCompat = { ...React, createElement: compatCreateElement };
+export default ReactCompat;
 
 // Export individual hooks and utilities
 export {

--- a/src/lib/react-utils/memo.ts
+++ b/src/lib/react-utils/memo.ts
@@ -19,4 +19,22 @@ export type VirtualElement = React.ReactElement;
 export const Fragment = React.Fragment;
 
 // createElement export
-export const createElement = React.createElement;
+export const createElement = (type: any, props: any, ...children: any[]) => {
+  if (props && typeof props.style === 'string') {
+    const styleObj: Record<string, string> = {};
+
+    props.style.split(';').forEach((part: string) => {
+      const [rawKey, rawValue] = part.split(':');
+      if (!rawKey || rawValue === undefined) {
+        return;
+      }
+
+      const key = rawKey.trim().replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      styleObj[key] = rawValue.trim();
+    });
+
+    props = { ...props, style: styleObj };
+  }
+
+  return React.createElement(type, props, ...children);
+};

--- a/src/util/buildStyle.ts
+++ b/src/util/buildStyle.ts
@@ -1,5 +1,23 @@
+import type { CSSProperties } from 'react';
+
 type Parts = (string | false | undefined)[];
 
-export default function buildStyle(...parts: Parts) {
-  return parts.filter(Boolean).join(';');
+export default function buildStyle(...parts: Parts): CSSProperties | undefined {
+  const styleString = parts.filter(Boolean).join(';');
+  if (!styleString) {
+    return undefined;
+  }
+
+  const styleObj: Record<string, string> = {};
+  styleString.split(';').forEach((part) => {
+    const [rawKey, rawValue] = part.split(':');
+    if (!rawKey || rawValue === undefined) {
+      return;
+    }
+
+    const key = rawKey.trim().replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    styleObj[key] = rawValue.trim();
+  });
+
+  return styleObj as CSSProperties;
 }


### PR DESCRIPTION
## Summary
- normalize string style props into React style objects
- wire custom createElement into React compatibility layer
- broaden CSSProperties type to accept objects

## Testing
- `npm run check` *(fails: TS errors in unrelated files)*
- `curl -I http://localhost:1234`
- `node test-app.js` *(fails: missing Playwright system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a07b83eb18832cb6f4b667a16f6317